### PR TITLE
Opam 2.2.1 does deep git clone again

### DIFF
--- a/orb.opam
+++ b/orb.opam
@@ -9,12 +9,12 @@ depends: [
   "ocaml" {>= "4.10.0"}
   "dune" {>= "2.0"}
   "cmdliner" {>= "1.1.0"}
-  "opam-client" {>= "2.1.2" & < "2.2.0"}
-  "opam-repository" {>= "2.1.2" & < "2.2.0"}
-  "opam-core" {>= "2.1.2" & < "2.2.0"}
-  "opam-format" {>= "2.1.2" & < "2.2.0"}
-  "opam-solver" {>= "2.1.2" & < "2.2.0"}
-  "opam-state" {>= "2.1.2" & < "2.2.0"}
+  "opam-client" {>= "2.2.1"}
+  "opam-repository" {>= "2.2.1"}
+  "opam-core" {>= "2.2.1"}
+  "opam-format" {>= "2.2.1"}
+  "opam-solver" {>= "2.2.1"}
+  "opam-state" {>= "2.2.1"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/src/orb.ml
+++ b/src/orb.ml
@@ -77,12 +77,12 @@ let custom_env_keys = [
   "OS" ; "OS_DISTRIBUTION" ; "OS_VERSION" ; "OS_FAMILY" ; "SWITCH_PATH" ; "ORB_DATA"
 ]
 
-let retrieve_opam_vars _gt_vars = {
-  Common.os = OpamSysPoll.os () (* gt_vars *) ;
-  os_distribution = OpamSysPoll.os_distribution () (* gt_vars *) ;
-  os_version = OpamSysPoll.os_version () (* gt_vars *) ;
-  os_family = OpamSysPoll.os_family () (* gt_vars *) ;
-  arch = OpamSysPoll.arch () (* gt_vars *) ;
+let retrieve_opam_vars gt_vars = {
+  Common.os = OpamSysPoll.os gt_vars ;
+  os_distribution = OpamSysPoll.os_distribution gt_vars ;
+  os_version = OpamSysPoll.os_version gt_vars ;
+  os_family = OpamSysPoll.os_family gt_vars ;
+  arch = OpamSysPoll.arch gt_vars ;
 }
 
 let custom_env vars s = [


### PR DESCRIPTION
Thus we should be able to use the newer opam version again.

I plan on testing this, but we have a window of roughly 12-17 CEST where builds are being built on both our builder machines. So I would have to do it in the evening or in the morning, and I'm not sure when I'll find time for that (likely Monday if I don't forget in the morning).