### PR TITLE
Add compatibility to opam 2.5

### DIFF
--- a/src/orb.ml
+++ b/src/orb.ml
@@ -161,9 +161,9 @@ let output_system_packages_and_env ~skip_system ~os ~os_family dir env =
   end
 
 let drop_states ?gt ?rt ?st () =
-  OpamStd.Option.iter OpamSwitchState.drop st;
-  OpamStd.Option.iter OpamRepositoryState.drop rt;
-  OpamStd.Option.iter OpamGlobalState.drop gt
+  Stdlib.Option.iter OpamSwitchState.drop st;
+  Stdlib.Option.iter OpamRepositoryState.drop rt;
+  Stdlib.Option.iter OpamGlobalState.drop gt
 
 let switch_filename dir =
   let fn = Printf.sprintf "%s/%s" dir dot_switch in


### PR DESCRIPTION
See https://github.com/ocaml/opam/pull/6442

Option.iter exists since the module's introduction in OCaml 4.08 so this change is backward compatible.
The reason `Stdlib` has to be specified is because `extlib` (used by `cudf` and `dose3` through `opam-solver`) defines its own `Option` module