### PR TITLE
Use OpamCmdliner over Cmdliner

### DIFF
--- a/orb.opam
+++ b/orb.opam
@@ -9,12 +9,12 @@ depends: [
   "ocaml" {>= "4.10.0"}
   "dune" {>= "2.0"}
   "cmdliner" {>= "1.1.0"}
-  "opam-client" {>= "2.2.1"}
-  "opam-repository" {>= "2.2.1"}
-  "opam-core" {>= "2.2.1"}
-  "opam-format" {>= "2.2.1"}
-  "opam-solver" {>= "2.2.1"}
-  "opam-state" {>= "2.2.1"}
+  "opam-client" {>= "2.5.0"}
+  "opam-repository" {>= "2.5.0"}
+  "opam-core" {>= "2.5.0"}
+  "opam-format" {>= "2.5.0"}
+  "opam-solver" {>= "2.5.0"}
+  "opam-state" {>= "2.5.0"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/src/orb.ml
+++ b/src/orb.ml
@@ -979,7 +979,7 @@ let rebuild global_options disable_sandboxing build_options skip_system ignore_e
   end
 
 (** CLI *)
-open Cmdliner
+open OpamCmdliner
 open OpamArg
 
 let validity = cli_from cli2_1


### PR DESCRIPTION
We use bits from opam that now don't use Cmdliner but instead OpamCmdliner.

In opam 2.5.0 cmdliner is vendored so we can't use the `OpamCmdliner.Term.t`s with Cmdliner, so let's use OpamCmdliner. 